### PR TITLE
release: 0.3.1 — validate large templates via S3 URL

### DIFF
--- a/functions/cfn/tmpl/upload.sh
+++ b/functions/cfn/tmpl/upload.sh
@@ -17,7 +17,8 @@
 #?   [-k KEY]      S3 bucket object key.
 #?                 If omit this, a default key is generated with the basename of TEMPLATE.
 #?
-#?   [-v]          Validate the template before the upload.
+#?   [-v]          Validate the template (after the upload, via the S3 URL, so
+#?                 templates larger than the 51200-byte inline limit validate).
 #?
 #?   -t TEMPLATE   Template to upload.
 #?                 The TEMPLATE must be either of:
@@ -65,10 +66,18 @@ function upload () {
         return 255
     fi
 
+    # Upload first, then (optionally) validate via the uploaded S3 URL rather than
+    # the local file. CloudFormation's inline `--template-body` is capped at 51200
+    # bytes, while `--template-url` (S3) accepts templates up to its larger limit.
+    # Validating post-upload therefore lets large local templates (>51200 bytes)
+    # validate, which inline validation would reject with:
+    #   "templateBody ... Member must have length less than or equal to 51200".
+    declare uri
+    uri=$(xsh aws/s3/upload "${region_opt[@]}" -b "$bucket" -k "$key" -o https "$template")
+
     if [[ $validate -eq 1 ]]; then
-        # validate template
-        xsh aws/cfn/tmpl/validate -t "$template"
+        xsh aws/cfn/tmpl/validate -t "$uri"
     fi
 
-    xsh aws/s3/upload "${region_opt[@]}" -b "$bucket" -k "$key" -o https "$template"
+    printf '%s\n' "$uri"
 }


### PR DESCRIPTION
Release 0.3.1 (patch).

- **fix(cfn/tmpl/upload)**: `-v` validation now happens after the S3 upload, via `--template-url`, so templates larger than CloudFormation's 51200-byte inline `--template-body` limit validate and deploy (#8). Fixes `aws/cfn/vpn/deploy` for large templates (surfaced by aws-cfn-vpn's all-region arm64 RegionMap). Verified end-to-end on a 52299-byte template.
