### PR TITLE
fix(cfn/deploy): create/update stacks via S3 template URL (large templates)

### DIFF
--- a/functions/cfn/deploy.sh
+++ b/functions/cfn/deploy.sh
@@ -565,10 +565,15 @@ function deploy () {
     declare ret
 
     # create/update stack
+    #
+    # Use the uploaded S3 template URL ($uri), not the local file ($template):
+    # create-stack/update-stack pass a local template inline via --template-body,
+    # which CloudFormation caps at 51200 bytes. The S3 --template-url path (which
+    # $uri resolves to) supports larger templates, so big templates deploy.
     case $update in
         changeset)
             xsh log info "updating stack by change set: $stack_name"
-            aws-cfn-stack-update "${region_opt[@]}" -s "$stack_name" -S -t "$template" "${pass_options[@]}" \
+            aws-cfn-stack-update "${region_opt[@]}" -s "$stack_name" -S -t "$uri" "${pass_options[@]}" \
                 || ret=$?
             ;;
         direct)
@@ -576,7 +581,7 @@ function deploy () {
             if x-io-confirm \
                    -m "Direct update may cause unexpected reources recreation/replacement. Are You Sure?" \
                    -t 30; then
-                aws-cfn-stack-update "${region_opt[@]}" -s "$stack_name" -D -t "$template" "${pass_options[@]}" \
+                aws-cfn-stack-update "${region_opt[@]}" -s "$stack_name" -D -t "$uri" "${pass_options[@]}" \
                     || ret=$?
             else
                 ret=1
@@ -593,7 +598,7 @@ function deploy () {
                 pass_options+=( -R )
             fi
 
-            aws-cfn-stack-create "${region_opt[@]}" -s "$stack_name" -t "$template" "${pass_options[@]}" \
+            aws-cfn-stack-create "${region_opt[@]}" -s "$stack_name" -t "$uri" "${pass_options[@]}" \
                 || ret=$?
             ;;
     esac


### PR DESCRIPTION
Completes 0.3.1. The main template is uploaded to S3, but create/update-stack were still invoked with the local path → `--template-body` (51200-byte cap). Pass the S3 `$uri` (→ `--template-url`) instead. Verified: `create-change-set` with a 52299-byte template via `--template-url` against a live stack → CREATE_COMPLETE.