### PR TITLE
fix(cfn/vpn/config): unset Slack bot options for node stacks; refresh env docs

### DIFF
--- a/functions/cfn/vpn/__init__.sh
+++ b/functions/cfn/vpn/__init__.sh
@@ -38,6 +38,17 @@ XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SSM_VARS=(
     XACVC_XACC_OPTIONS_SSMDomainNameServerEnv
 )
 
+#? Slack bot options are gated on `EnableSSM=1` (manager side). They are
+#? registered here so the config generator unsets them for node stacks
+#? (stack type 1), the same way it unsets the other SSM options. Otherwise a
+#? Slack signing secret set in the environment would be injected into node
+#? config files should the node template ever list the Slack options.
+XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SLACK_VARS=(
+    XACVC_XACC_OPTIONS_SlackSigningSecret
+    XACVC_XACC_OPTIONS_SlackAllowedUsers
+    XACVC_XACC_OPTIONS_SlackAllowedChannels
+)
+
 XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SS_VARS=(
     XACVC_XACC_OPTIONS_SSManagerInterface
     XACVC_XACC_OPTIONS_SSManagerPort

--- a/functions/cfn/vpn/config.sh
+++ b/functions/cfn/vpn/config.sh
@@ -157,8 +157,10 @@
 #?   - XACVC_XACC_OPTIONS_VpcPeerAcceptorCidrBlock
 #?   - XACVC_XACC_OPTIONS_VpcPeerAcceptorSqsQueueUrl
 #?
-#?   - XACVC_XACC_OPTIONS_EnableLexBot
-#?   - XACVC_XACC_OPTIONS_LexBotRegion
+#?   - XACVC_XACC_OPTIONS_EnableSlackBot
+#?   - XACVC_XACC_OPTIONS_SlackSigningSecret
+#?   - XACVC_XACC_OPTIONS_SlackAllowedUsers
+#?   - XACVC_XACC_OPTIONS_SlackAllowedChannels
 #?
 #?   - XACVC_XACC_OPTIONS_EnableConfigConsumer
 #?   - XACVC_XACC_OPTIONS_EnableConfigProvider
@@ -282,7 +284,7 @@ function config () {
             unset ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SS_VARS[@]}
         elif [[ $stack_type == 1 ]]; then
             # shellcheck disable=SC2068
-            unset ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SSM_VARS[@]} ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_L2TP_VARS[@]}
+            unset ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SSM_VARS[@]} ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_L2TP_VARS[@]} ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SLACK_VARS[@]}
         fi
     }
 


### PR DESCRIPTION
## Why

The `aws-cfn-vpn` template retired LexBot in favour of a **Slack slash-command bot** (manager-side, gated on `EnableSSM=1`), adding the parameters `EnableSlackBot`, `SlackSigningSecret`, `SlackAllowedUsers`, `SlackAllowedChannels`.

The `cfn/vpn/config` generator unsets manager-side option env vars when emitting **node** (stack type 1) configs, via the per-group arrays in `__init__.sh` (`SSM_VARS`, `L2TP_VARS`). The new Slack options were registered nowhere, so they were missing from that unset logic. Because `__replace_option_value_by_name__` injects a value even into a **commented** option line, a `SlackSigningSecret` set in the environment would be written into node config files the moment the node template lists the Slack options (commented or not) — a latent secret-leak / cross-contamination gap.

## What

- **`__init__.sh`** — add `XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SLACK_VARS` (`SlackSigningSecret`, `SlackAllowedUsers`, `SlackAllowedChannels`); excludes the `EnableSlackBot` toggle, matching the `SSM_VARS` convention (which omits `EnableSSM`).
- **`config.sh`** — append `SLACK_VARS` to the node (type 1) `unset`; replace the stale `EnableLexBot` / `LexBotRegion` env-var docs with the four Slack options.

## Test

Exercised the real edited arrays + real `config-templates` through the unset + option-replace path (sed dialect matched to this host):

| Case | Stack | Template | Slack secret in output | Expected |
|------|-------|----------|------------------------|----------|
| A | manager (0) | real `OPTIONS-0` | PRESENT | ✅ manager keeps Slack |
| B | node (1) | real `OPTIONS-1` (no Slack line today) | ABSENT | ✅ unchanged, no leak |
| C | node (1) | future (commented Slack line) **with fix** | ABSENT | ✅ leak prevented |
| D | node (1) | future (commented Slack line) **without fix** | PRESENT | ✗ the leak this closes |

No regression to the manager (A), no change to today's node behaviour (B), and the C↔D delta shows the fix doing real work. `bash -n` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
