### PR TITLE
Release 0.3.3: fix Slack bot option handling in cfn/vpn/config

### DIFF
--- a/functions/cfn/vpn/__init__.sh
+++ b/functions/cfn/vpn/__init__.sh
@@ -38,6 +38,17 @@ XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SSM_VARS=(
     XACVC_XACC_OPTIONS_SSMDomainNameServerEnv
 )
 
+#? Slack bot options are gated on `EnableSSM=1` (manager side). They are
+#? registered here so the config generator unsets them for node stacks
+#? (stack type 1), the same way it unsets the other SSM options. Otherwise a
+#? Slack signing secret set in the environment would be injected into node
+#? config files should the node template ever list the Slack options.
+XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SLACK_VARS=(
+    XACVC_XACC_OPTIONS_SlackSigningSecret
+    XACVC_XACC_OPTIONS_SlackAllowedUsers
+    XACVC_XACC_OPTIONS_SlackAllowedChannels
+)
+
 XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SS_VARS=(
     XACVC_XACC_OPTIONS_SSManagerInterface
     XACVC_XACC_OPTIONS_SSManagerPort

--- a/functions/cfn/vpn/config.sh
+++ b/functions/cfn/vpn/config.sh
@@ -157,8 +157,10 @@
 #?   - XACVC_XACC_OPTIONS_VpcPeerAcceptorCidrBlock
 #?   - XACVC_XACC_OPTIONS_VpcPeerAcceptorSqsQueueUrl
 #?
-#?   - XACVC_XACC_OPTIONS_EnableLexBot
-#?   - XACVC_XACC_OPTIONS_LexBotRegion
+#?   - XACVC_XACC_OPTIONS_EnableSlackBot
+#?   - XACVC_XACC_OPTIONS_SlackSigningSecret
+#?   - XACVC_XACC_OPTIONS_SlackAllowedUsers
+#?   - XACVC_XACC_OPTIONS_SlackAllowedChannels
 #?
 #?   - XACVC_XACC_OPTIONS_EnableConfigConsumer
 #?   - XACVC_XACC_OPTIONS_EnableConfigProvider
@@ -282,7 +284,7 @@ function config () {
             unset ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SS_VARS[@]}
         elif [[ $stack_type == 1 ]]; then
             # shellcheck disable=SC2068
-            unset ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SSM_VARS[@]} ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_L2TP_VARS[@]}
+            unset ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SSM_VARS[@]} ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_L2TP_VARS[@]} ${XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SLACK_VARS[@]}
         fi
     }
 


### PR DESCRIPTION
Release **0.3.3**.

Ships one fix (squashed [#12](https://github.com/xsh-lib/aws/pull/12)):

- `fix(cfn/vpn/config)`: register the Slack bot options in a new `XSH_AWS_CFN_VPN__CONFIG_OPTIONS_SLACK_VARS` array and unset them for node (stack type 1) configs — preventing a Slack signing secret set in the environment from leaking into node config files; also replaces the stale `EnableLexBot`/`LexBotRegion` env-var docs with the Slack options.

Release-diff gate: `origin/master..origin/develop` is exactly this one commit; `master` and `develop` were otherwise content-identical (prior drift was merge-commit bubbles only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
